### PR TITLE
채팅 채널 구독 취소 로직 추가

### DIFF
--- a/src/main/java/com/example/naejango/domain/chat/api/WebSocketController.java
+++ b/src/main/java/com/example/naejango/domain/chat/api/WebSocketController.java
@@ -4,17 +4,23 @@ import com.example.naejango.domain.chat.application.MessageService;
 import com.example.naejango.domain.chat.dto.SendMessageRequestDto;
 import com.example.naejango.domain.chat.dto.SendMessageResponseDto;
 import com.example.naejango.domain.chat.dto.SubscribeResponseDto;
+import com.example.naejango.domain.chat.dto.response.UnsubscribeResponseDto;
+import com.example.naejango.global.common.exception.CustomException;
+import com.example.naejango.global.common.exception.ErrorCode;
+import com.example.naejango.global.common.exception.WebSocketErrorResponse;
+import com.example.naejango.global.common.exception.WebSocketException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -23,31 +29,76 @@ import java.util.concurrent.ConcurrentMap;
 @RequiredArgsConstructor
 public class WebSocketController {
     private final MessageService messageService;
-    ConcurrentMap<Long, Set<Long>> topicSubscribers = new ConcurrentHashMap<>();
+    ConcurrentMap<Long, Set<Long>> subscribeInfoMap = new ConcurrentHashMap<>();
 
-    /**
-     * SendTo 로 맵핑된 Channel 에 메세지를 보내는 api
-     */
+    /** 웹소켓 통신 중 정보를 수신하는 채널을 구독하는 Endpoint */
+    @SubscribeMapping("/user/queue/info")
+    public SubscribeResponseDto subscribeInfoChannel() {
+        return SubscribeResponseDto.builder().message("소켓 통신 정보를 수신합니다.").build();
+    }
+
+    /** 채팅 Channel 을 구독하는 Endpoint */
+    @SubscribeMapping("/topic/channel/{channelId}")
+    public SubscribeResponseDto subscribeChatChannel(@DestinationVariable("channelId") Long channelId, SimpMessageHeaderAccessor accessor) {
+        Long userId = getUserId(accessor);
+        subscribeInfoMap.computeIfAbsent(channelId, k -> new HashSet<>()).add(userId);
+        return SubscribeResponseDto.builder().userId(userId).message("채팅 채널 구독을 시작합니다.").subscribingChannelId(channelId).build();
+    }
+
+    /** 채팅 Channel 에 메세지를 보내는 Endpoint */
     @MessageMapping("/chat/channel/{channelId}")
     @SendTo("/topic/channel/{channelId}")
     public SendMessageResponseDto sendMessage(@RequestBody SendMessageRequestDto requestDto,
                                               @DestinationVariable("channelId") Long channelId,
                                               SimpMessageHeaderAccessor headerAccessor) {
-        Long senderId = Long.valueOf((String) Objects.requireNonNull(headerAccessor.getHeader("userId")));
-        messageService.publishMessage(channelId, senderId, requestDto.getContent(), topicSubscribers.get(channelId));
+        Long senderId = getUserId(headerAccessor);
+        messageService.publishMessage(channelId, senderId, requestDto.getContent(), subscribeInfoMap.get(channelId));
         return new SendMessageResponseDto(senderId, channelId, requestDto.getContent());
     }
 
     /**
-     * 특정 Channel 을 구독하는 api
-     * 구독 요청시 한번만 동작하는 로직입니다.
+     * 구독을 취소하는 Endpoint
+     * UNSUBSCRIBE 가 아닌 MESSAGE/SEND 명령으로 HashMap 에 등록되어있는 구독 정보를 지우는 용도입니다
      */
-    @SubscribeMapping("/topic/channel/{channelId}")
-    public SubscribeResponseDto subscribeChannel(@DestinationVariable("channelId") Long channelId, SimpMessageHeaderAccessor headerAccessor) {
-        Long requestUserId = Long.valueOf((String) Objects.requireNonNull(headerAccessor.getHeader("userId")));
-        topicSubscribers.computeIfAbsent(channelId, k -> new HashSet<>()).add(requestUserId);
-        return SubscribeResponseDto.builder().userId(requestUserId).message("채팅 채널 구독을 시작합니다.").subscribingChannelId(channelId).build();
+    @MessageMapping("/unsubscribe")
+    @SendToUser("/queue/info")
+    public UnsubscribeResponseDto unsubscribeChannel(SimpMessageHeaderAccessor accessor) {
+        Long userId = getUserId(accessor);
+        Long channelId = getChannelId(accessor);
+
+        // 구독 정보 지우기
+        subscribeInfoMap.computeIfPresent(channelId, (key, set) -> {
+            if(!set.remove(userId)) throw new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND);
+            return set;
+        });
+
+        return UnsubscribeResponseDto.builder().userId(userId).unsubscribedChannelId(channelId).message("채팅 채널 구독이 취소 되었습니다.").build();
     }
 
+    /** 웹소켓 통신 중 발생하는 예외를 핸들링합니다. */
+    @MessageExceptionHandler
+    @SendToUser("/queue/info")
+    public WebSocketErrorResponse handleException(Throwable e) {
+        if (e instanceof WebSocketException) {
+            WebSocketException exception = (WebSocketException) e;
+            return WebSocketErrorResponse.response(exception.getErrorCode());
+        }
+        e.printStackTrace();
+        return WebSocketErrorResponse.builder().error(e.getMessage()).message("통신 중 에러가 발생하였습니다.").build();
+    }
+
+    private Long getUserId(SimpMessageHeaderAccessor accessor) {
+        Object channelId = accessor.getHeader("userId");
+        if(channelId instanceof Long) return (Long) channelId;
+        if(channelId instanceof String) return Long.valueOf((String) channelId);
+        return null;
+    }
+
+    private Long getChannelId(SimpMessageHeaderAccessor accessor) {
+        Object channelId = accessor.getHeader("channelId");
+        if(channelId instanceof Long) return (Long) channelId;
+        if(channelId instanceof String) return Long.valueOf((String) channelId);
+        return null;
+    }
 
 }

--- a/src/main/java/com/example/naejango/domain/chat/config/WebSocketChannelInterceptor.java
+++ b/src/main/java/com/example/naejango/domain/chat/config/WebSocketChannelInterceptor.java
@@ -5,15 +5,22 @@ import com.example.naejango.global.auth.jwt.JwtValidator;
 import com.example.naejango.global.common.exception.CustomException;
 import com.example.naejango.global.common.exception.ErrorCode;
 import com.example.naejango.global.common.exception.WebSocketException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @Component
 @RequiredArgsConstructor
@@ -22,60 +29,154 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
 
     private final JwtValidator jwtValidator;
     private final ChannelService channelService;
+
     /**
-     * 채널 구독 및 메세지 송신 관련 메서드 입니다.
-     * 웹소켓 연결된 사용자가 구독 또는 메세지 송신시 요청을 가로채는 Filter 역할을 합니다.
+     * 구독 정보를 저장하는 ConcurrentHashMap 입니다.
+     * 구독 신청이나 메세지 전송의 경우 항상 토큰 정보를 검증하기 때문에
+     * UserId로 사용자를 식별할 수 있지만 구독 취소 요청의 경우
+     * 별다른 토큰 정보 없이도 구독을 취소할 수 있도록
+     * UserId 가 아닌 Session Id 를 식별자로 사용합니다.
+     * SessionId : (userId, subscribeId, channelId)
+     */
+    ConcurrentMap<String, SubscriptionInfo> subscriptionInfoMap = new ConcurrentHashMap<>();
+
+    /**
+     * 웹소켓 EndPoint 로 전송되는 메세지를 Intercept 하여
+     * 사용자 인증, 구독 취소 등의 기능을 수행합니다.
      */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         accessor.setLeaveMutable(true);
-        if (accessor.getCommand().equals(StompCommand.CONNECT)) {
+
+        /** 구독 취소 요청 */
+        if(accessor.getCommand().equals(StompCommand.UNSUBSCRIBE)){
+            Message unsubscribeMessage = createUnsubscribeMessage(accessor);
+            channel.send(unsubscribeMessage);
             return message;
         }
 
-        if (accessor.getCommand().equals(StompCommand.SUBSCRIBE)) {
-            Long subscriberId = getUserIdFromToken(accessor);
-            Long channelId = getChannelId(accessor);
-            if(channelService.isParticipants(channelId, subscriberId)) throw new WebSocketException(ErrorCode.UNAUTHORIZED_SUBSCRIBE_REQUEST);
-            accessor.setHeader("userId", String.valueOf(subscriberId));
-            return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+        /** 웹소켓 연결 종료 요청 */
+        if (accessor.getCommand().equals(StompCommand.DISCONNECT)) {
+            if (subscriptionInfoMap.containsKey(accessor.getSessionId())) {
+                channel.send(createUnsubscribeMessage(accessor));
+            }
+            return message;
         }
 
-        if (accessor.getCommand().equals(StompCommand.SEND)) {
-            Long senderId = getUserIdFromToken(accessor);
+        /** 여기서 부터는 보안이 필요한 로직을 다룹니다. **/
+        /** 웹소켓 연결 요청 : 토큰 검증 */
+        if (accessor.getCommand().equals(StompCommand.CONNECT)) {
+            validateTokenAndGetId(accessor);
+            if(subscriptionInfoMap.containsKey(accessor.getSessionId())) throw new WebSocketException(ErrorCode.SESSION_ALREADY_EXIST);
+            return message;
+        }
+
+        /** 구독 요청 : 토큰 검증 및 채널 입장 권한 검증 */
+        if (accessor.getCommand().equals(StompCommand.SUBSCRIBE)) {
+            // 기본적인 토큰 검증
+            Long userId = validateTokenAndGetId(accessor);
+
+            // 정보 수신 채널 구독
+            if(accessor.getDestination().equals("/user/queue/info")) {
+                return messageWithUserIdHeader(message, accessor, userId);
+            }
+
+            // 채팅 채널 구독
             Long channelId = getChannelId(accessor);
-            if(channelService.isParticipants(channelId, senderId)) throw new WebSocketException(ErrorCode.UNAUTHORIZED_SEND_MESSAGE_REQUEST);
-            accessor.setHeader("userId", String.valueOf(senderId));
-            return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+            if(!channelService.isParticipants(channelId, userId)) throw new WebSocketException(ErrorCode.UNAUTHORIZED_SUBSCRIBE_REQUEST);
+
+            // 구독 정보 등록
+            subscriptionInfoMap.compute(accessor.getSessionId(), (sessionId, Info) -> {
+                if(Info != null) throw new WebSocketException(ErrorCode.SESSION_ALREADY_EXIST);
+                return new SubscriptionInfo(userId, accessor.getSubscriptionId(), channelId);
+            });
+
+            return messageWithUserIdHeader(message, accessor, userId);
+        }
+
+        /** 메세지 전송 요청 : 토큰 검증 및 메세지 발송 권한 인증*/
+        if (accessor.getCommand().equals(StompCommand.SEND) || accessor.getCommand().equals(StompCommand.MESSAGE)) {
+            // 구독 취소 요청
+            if(accessor.getDestination().equals("/unsubscribe")) return message;
+
+            // 발송 권한 확인 - 이미 채널을 구독 중인 경우에는 토큰 검증하지 않음
+            Long channelId = getChannelId(accessor);
+            String sessionId = accessor.getSessionId();
+            if (subscriptionInfoMap.containsKey(sessionId)) {
+                SubscriptionInfo subscriptionInfo = subscriptionInfoMap.get(sessionId);
+                if (subscriptionInfo.getChannelId().equals(channelId)) {
+                    return messageWithUserIdHeader(message, accessor, subscriptionInfo.getUserId());
+                }
+            }
+
+            // 기본적인 토큰 검증
+            Long userId = validateTokenAndGetId(accessor);
+
+            // 메시지 발송 권한 검증
+            if(!channelService.isParticipants(channelId, userId)) throw new WebSocketException(ErrorCode.UNAUTHORIZED_SEND_MESSAGE_REQUEST);
+            return messageWithUserIdHeader(message, accessor, userId);
         }
 
         return null;
     }
 
+    private Message<?> createUnsubscribeMessage(StompHeaderAccessor accessor) {
+        StompHeaderAccessor unsubscribeAccessor = StompHeaderAccessor.create(StompCommand.SEND);
+        unsubscribeAccessor.setMessageTypeIfNotSet(SimpMessageType.MESSAGE);
+        unsubscribeAccessor.setSessionId(accessor.getSessionId());
+        unsubscribeAccessor.setSessionAttributes(accessor.getSessionAttributes());
+        subscriptionInfoMap.computeIfPresent(accessor.getSessionId(), (sessionId, Info) -> {
+            unsubscribeAccessor.setSessionId(accessor.getSessionId());
+            unsubscribeAccessor.setHeader("userId", Info.userId);
+            unsubscribeAccessor.setSubscriptionId(Info.subscriptionId);
+            unsubscribeAccessor.setHeader("channelId", Info.channelId);
+            unsubscribeAccessor.setDestination("/unsubscribe");
+            return null;
+        });
+        subscriptionInfoMap.remove(accessor.getSessionId());
+        return MessageBuilder.createMessage(new byte[0], unsubscribeAccessor.getMessageHeaders());
+    }
+
+    private static Message<?> messageWithUserIdHeader(Message<?> message, StompHeaderAccessor accessor, Long userId) {
+        accessor.setHeader("userId", userId);
+        return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+    }
+
     /**
      * header 에 포함된 accessToken 을 복호화 하여 UserId 를 가지고 옵니다.
+     * 기본적인 AccessToken 검증을 수행합니다.
      */
-    private Long getUserIdFromToken(StompHeaderAccessor headerAccessor) {
+    private Long validateTokenAndGetId(StompHeaderAccessor headerAccessor) {
         try {
             var validateRequest = jwtValidator.validateTokenInRequest(headerAccessor);
-            if (!validateRequest.isValidToken()) throw new CustomException(ErrorCode.UNAUTHORIZED);
+            if (!validateRequest.isValidToken()) throw new WebSocketException(ErrorCode.ACCESS_TOKEN_NOT_VALID);
             return validateRequest.getUserId();
         } catch (CustomException e) {
-            throw new WebSocketException(ErrorCode.TOKEN_DECRYPTION_FAILURE);
+            throw new WebSocketException(ErrorCode.ACCESS_TOKEN_NOT_VALID);
         }
     }
 
     /**
-     * 채널 정보 추출 (예외 처리 필요)
+     * 채널 정보를 추출합니다.
      */
-
     private Long getChannelId(StompHeaderAccessor headerAccessor) {
         String destination = headerAccessor.getDestination();
-        String channelId = destination.substring(destination.lastIndexOf('/') + 1);
-        return Long.valueOf(channelId);
+        if(destination != null && (destination.startsWith("/chat/channel") || destination.startsWith("/topic/channel"))){
+            String channelId = destination.substring(destination.lastIndexOf('/') + 1);
+            return Long.valueOf(channelId);
+        }
+        throw new WebSocketException(ErrorCode.UNIDENTIFIED_DESTINATION);
     }
 
+
+    @Getter
+    @AllArgsConstructor
+    @ToString
+    private static class SubscriptionInfo {
+        private Long userId;
+        private String subscriptionId;
+        private Long channelId;
+    }
 
 }

--- a/src/main/java/com/example/naejango/domain/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/example/naejango/domain/chat/config/WebSocketConfig.java
@@ -11,7 +11,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
-public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketChannelInterceptor webSocketChannelInterceptor;
     private final StompErrorHandler stompErrorHandler;
@@ -29,7 +29,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/topic", "/queue");
         registry.setApplicationDestinationPrefixes("");
     }
 

--- a/src/main/java/com/example/naejango/domain/chat/dto/response/UnsubscribeResponseDto.java
+++ b/src/main/java/com/example/naejango/domain/chat/dto/response/UnsubscribeResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.naejango.domain.chat.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class UnsubscribeResponseDto {
+
+    private Long userId;
+    private Long unsubscribedChannelId;
+    private String message;
+
+}

--- a/src/main/java/com/example/naejango/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/example/naejango/domain/chat/repository/ChatRepository.java
@@ -34,14 +34,10 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Query("UPDATE Chat c SET c.lastMessage = :msg WHERE c.channelId = :channelId")
     void updateLastMessageByChannelId(@Param("channelId") Long channelId, @Param("msg") String msg);
 
-    @Query("SELECT u FROM Channel cnl JOIN cnl.channelUsers cu JOIN cu.user u WHERE cnl.id = :channelId")
-    List<User> findUserByChannelId(@Param("channelId") Long channelId);
-
     int countByChannelIdAndOwnerId(Long channelId, Long ownerId);
     int countByIdAndOwnerId(Long chatId, Long ownerId);
 
-    List<Chat> findChatByChannelId(Long channelId);
-
-    Optional<Chat> findChatById(Long chatId);
+    @Query("SELECT c FROM Chat c WHERE c.channelId = :channelId")
+    List<Chat> findChatByChannelId(@Param("channelId") Long channelId);
 
 }

--- a/src/main/java/com/example/naejango/global/auth/api/AuthController.java
+++ b/src/main/java/com/example/naejango/global/auth/api/AuthController.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.example.naejango.domain.user.application.UserService;
 import com.example.naejango.global.auth.dto.response.GuestLoginResponse;
+import com.example.naejango.global.auth.dto.response.ReissueAccessTokenResponseDto;
 import com.example.naejango.global.auth.jwt.AccessTokenReissuer;
 import com.example.naejango.global.auth.jwt.JwtCookieHandler;
 import com.example.naejango.global.auth.jwt.JwtProperties;
@@ -50,8 +51,21 @@ public class AuthController {
             userService.deleteSignature(userId);
         }
 
-        return ResponseEntity.ok().body(new LogoutResponseDto("Jwt 가 정상 삭제되었습니다."));
+        return ResponseEntity.ok().body(new LogoutResponseDto("토큰이 정상 삭제되었습니다."));
     }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<ReissueAccessTokenResponseDto> refreshAccessToken(HttpServletRequest request) {
+        String reissueAccessToken = accessTokenReissuer.reissueAccessToken(request);
+
+        if (reissueAccessToken == null) {
+            throw new CustomException(ErrorCode.REISSUE_TOKEN_FAILURE);
+        }
+
+        return ResponseEntity.ok().body(new ReissueAccessTokenResponseDto(ErrorCode.ACCESS_TOKEN_REISSUE, reissueAccessToken));
+    }
+
+
 
     /**
      * 둘러보기 회원 (게스트) 용 jwt 발급 api

--- a/src/main/java/com/example/naejango/global/auth/dto/response/ReissueAccessTokenResponseDto.java
+++ b/src/main/java/com/example/naejango/global/auth/dto/response/ReissueAccessTokenResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.naejango.global.auth.dto;
+package com.example.naejango.global.auth.dto.response;
 
 import com.example.naejango.global.common.exception.ErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/naejango/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/naejango/global/common/exception/ErrorCode.java
@@ -6,14 +6,15 @@ public enum ErrorCode {
     /** 400 BAD_REQUEST : 잘못된 요청 */
     ALREADY_LOGGED_IN(HttpStatus.BAD_REQUEST, "이미 로그인 된 회원입니다."),
     STORAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "창고가 등록되어있지 않습니다."),
+    UNIDENTIFIED_DESTINATION(HttpStatus.BAD_REQUEST, "채널 지정이 잘못되었습니다."),
     TRANSACTION_NOT_MODIFICATION(HttpStatus.BAD_REQUEST, "수정 할 수 없는 거래입니다."),
     TRANSACTION_NOT_DELETE(HttpStatus.BAD_REQUEST, "삭제 할 수 없는 거래입니다."),
-    FORGED_REQUEST(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
+    REISSUE_TOKEN_FAILURE(HttpStatus.BAD_REQUEST, "토큰 발급에 실패했습니다."),
 
     /** 401 UNAUTHORIZED : 권한 없음 */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "회원에게 요청 권한이 없습니다."),
     NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "로그인 되어 있지 않은 상태입니다."),
-    TOKEN_DECRYPTION_FAILURE(HttpStatus.UNAUTHORIZED, "액세스 토큰 복호화에 실패하였습니다."),
+    TOKEN_DECRYPTION_FAILURE(HttpStatus.UNAUTHORIZED, "액세스화 토큰 복호화에 실패하였습니다."),
     NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 요청입니다. 엑세스 토큰 및 리프레시 토큰을 찾을 수 없습니다."),
     ACCESS_TOKEN_REISSUE(HttpStatus.UNAUTHORIZED, "엑세스 토큰을 재발급 합니다."),
     ACCESS_TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "엑세스 토큰을 찾을 수 없거나, 만료된 엑세스 토큰입니다."),
@@ -22,14 +23,14 @@ public enum ErrorCode {
     UNAUTHORIZED_MODIFICATION_REQUEST(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
     UNAUTHORIZED_DELETE_REQUEST(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다."),
     UNAUTHORIZED_SUBSCRIBE_REQUEST(HttpStatus.FORBIDDEN, "채팅 채널 입장 권한이 없습니다."),
-    UNAUTHORIZED_SEND_MESSAGE_REQUEST(HttpStatus.FORBIDDEN, "채팅 채널 입장 권한이 없습니다."),
+    UNAUTHORIZED_SEND_MESSAGE_REQUEST(HttpStatus.FORBIDDEN, "해당 채팅 채널에 메세지를 보낼 권한이 없습니다."),
     SIGNUP_INCOMPLETE(HttpStatus.FORBIDDEN, "회원가입 절차가 완료되지 않은 회원입니다."),
 
     /** 404 NOT_FOUND : 리소스를 찾을 수 없음 */
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메세지를 찾을 수 없습니다."),
-    CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, " 해당하는 정보의 채팅을 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 User를 찾을 수 없습니다."),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 정보를 찾을 수 없습니다."),
     USERPROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 프로필을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 User 를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Category를 찾을 수 없습니다."),
     STORAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Storage를 찾을 수 없습니다."),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Item을 찾을 수 없습니다."),
@@ -38,6 +39,7 @@ public enum ErrorCode {
     TRANSACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 Transaction을 찾을 수 없습니다."),
 
     /** 409 : CONFLICT : 리소스의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
+    SESSION_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 채팅이 진행중인 채팅이 있습니다."),
     TOKEN_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 리프레시 토큰을 가지고 있습니다. 엑세스 토큰을 재발급 합니다."),
     WISH_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 관심 등록 되어있습니다."),
     FOLLOW_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 팔로우 등록 되어있습니다.")

--- a/src/test/java/com/example/naejango/domain/chat/api/WebSocketTest.java
+++ b/src/test/java/com/example/naejango/domain/chat/api/WebSocketTest.java
@@ -1,7 +1,7 @@
 package com.example.naejango.domain.chat.api;
 
-import com.example.naejango.domain.chat.dto.SendMessageResponseDto;
 import com.example.naejango.domain.chat.dto.SubscribeResponseDto;
+import com.example.naejango.domain.chat.dto.response.UnsubscribeResponseDto;
 import com.example.naejango.domain.chat.repository.*;
 import com.example.naejango.domain.user.domain.User;
 import com.example.naejango.domain.user.repository.UserProfileRepository;
@@ -70,11 +70,13 @@ public class WebSocketTest {
     DataSourceProperties dataSourceProperties;
 
     private final String ENDPOINT = "/ws-endpoint";
-    private final String TEST_SUBSCRIBE = "/topic/channel";
-    private final String TEST_SEND = "/chat/channel";
+    private final String CHAT_CHANNEL = "/topic/channel";
+    private final String INFO_CHANNEL = "/user/queue/info";
+    private final String SEND_MESSAGE_CHANNEL = "/chat/channel";
     private WebSocketStompClient stompClient;
     private StompSession stompSession;
     private BlockingQueue<String> blockingQueue;
+
 
     @BeforeEach
     public void setup() {
@@ -91,54 +93,63 @@ public class WebSocketTest {
         assertTrue(stompSession.isConnected());
     }
     @Test
-    @DisplayName("채널 Subscribe 테스트 ")
-    void test3() throws ExecutionException, InterruptedException, TimeoutException, JsonProcessingException {
+    @DisplayName("Info 채널 구독 테스트 ")
+    void info() throws ExecutionException, InterruptedException, TimeoutException, JsonProcessingException {
         // given
         stompSession = stompClient.connect("ws://localhost:8080" + ENDPOINT, new StompSessionHandlerAdapter() {}).get(1, SECONDS);
+
+        // when
+        StompHeaders subscribeHeaders = new StompHeaders();
         User user1 = userRepository.findByUserKey("test_1").get();
         String accessToken = jwtGenerator.generateAccessToken(user1.getId());
-
-        StompHeaders subscribeHeaders = new StompHeaders();
         subscribeHeaders.add("Authorization", JwtProperties.ACCESS_TOKEN_PREFIX + accessToken);
-        subscribeHeaders.setDestination(TEST_SUBSCRIBE +"/1");
-        // when
+        subscribeHeaders.setDestination(INFO_CHANNEL);
         stompSession.subscribe(subscribeHeaders, new DefaultStompFrameHandler());
         Thread.sleep(100);
 
         // then
-        var dto = new SubscribeResponseDto(1L, 1L, "채팅 채널 구독을 시작합니다.");
+        var dto = new SubscribeResponseDto(1L, null, "소켓 통신 정보를 수신합니다.");
         assertEquals(objectMapper.writeValueAsString(dto), blockingQueue.poll());
     }
 
     @Test
-    @DisplayName("메세지 send 테스트")
-    void test4() throws ExecutionException, InterruptedException, TimeoutException, JsonProcessingException {
+    @DisplayName("채팅 채널 구독 - 구독 취소 테스트")
+    void chatChannelSubscribeTest() throws ExecutionException, InterruptedException, TimeoutException, JsonProcessingException {
         // given
-        stompSession = stompClient.connect("http://localhost:8080" + ENDPOINT, new StompSessionHandlerAdapter() {}).get(1, SECONDS);
-
-        User user2 = userRepository.findByUserKey("test_2").get();
-        String accessToken = jwtGenerator.generateAccessToken(user2.getId());
-
-        StompHeaders subscribeHeaders = new StompHeaders();
-        subscribeHeaders.add("Authorization", JwtProperties.ACCESS_TOKEN_PREFIX + accessToken);
-        subscribeHeaders.setDestination(TEST_SUBSCRIBE +"/1");
-        stompSession.subscribe(subscribeHeaders, new DefaultStompFrameHandler());
-        Thread.sleep(200);
+        stompSession = stompClient.connect("ws://localhost:8080" + ENDPOINT, new StompSessionHandlerAdapter() {}).get(1, SECONDS);
 
         // when
-        StompHeaders messageHeaders = new StompHeaders();
-        messageHeaders.setDestination(TEST_SEND + "/1");
-        messageHeaders.add("Authorization", JwtProperties.ACCESS_TOKEN_PREFIX + accessToken);
+        DefaultStompFrameHandler defaultStompFrameHandler = new DefaultStompFrameHandler();
+        User user1 = userRepository.findByUserKey("test_1").get();
+        String accessToken = jwtGenerator.generateAccessToken(user1.getId());
+        System.out.println("accessToken = " + accessToken);
 
-        var requestDto1 = SendMessageResponseDto.builder().senderId(user2.getId()).content("테스트 메세지").channelId(1L).build();
-        stompSession.send(messageHeaders, objectMapper.writeValueAsBytes(requestDto1));
+        // info 채널 구독
+        StompHeaders subscribeInfoHeaders = new StompHeaders();
+        subscribeInfoHeaders.add("Authorization", JwtProperties.ACCESS_TOKEN_PREFIX + accessToken);
+        subscribeInfoHeaders.setDestination(INFO_CHANNEL);
+        stompSession.subscribe(subscribeInfoHeaders, defaultStompFrameHandler);
+        Thread.sleep(100);
+
+        // 채팅 채널 구독
+        StompHeaders subscribeChatHeaders = new StompHeaders();
+        subscribeChatHeaders.add("Authorization", JwtProperties.ACCESS_TOKEN_PREFIX + accessToken);
+        subscribeChatHeaders.setDestination(CHAT_CHANNEL + "/1");
+        StompSession.Subscription subscription = stompSession.subscribe(subscribeChatHeaders, defaultStompFrameHandler);
+        Thread.sleep(200);
+
+        // 구독 취소
+        subscription.unsubscribe();
         Thread.sleep(100);
 
         // then
-        var dto1 = new SubscribeResponseDto(2L, 1L, "채팅 채널 구독을 시작합니다.");
-        assertEquals(objectMapper.writeValueAsString(dto1), blockingQueue.poll(1, SECONDS));
-        var dto2 = new SendMessageResponseDto(2L, 1L, "테스트 메세지"); // 보낸 메세지가 구독 되었던 채널로 돌아옴
-        assertEquals(objectMapper.writeValueAsString(dto2), blockingQueue.poll(1, SECONDS));
+        var dto = new SubscribeResponseDto(1L, null, "소켓 통신 정보를 수신합니다.");
+        assertEquals(objectMapper.writeValueAsString(dto), blockingQueue.poll());
+        var dto2 = new SubscribeResponseDto(1L, 1L, "채팅 채널 구독을 시작합니다.");
+        assertEquals(objectMapper.writeValueAsString(dto2), blockingQueue.poll());
+        var dto3 = new UnsubscribeResponseDto(1L, 1L, "채팅 채널 구독이 취소 되었습니다.");
+        assertEquals(objectMapper.writeValueAsString(dto3), blockingQueue.poll());
+
     }
 
     private class DefaultStompFrameHandler implements StompFrameHandler {


### PR DESCRIPTION
- 구독 취소 로직 추가하여 메세지 읽음 기능 구현 완료
- AuthController 에 엑세스 토큰 재발행 api 추가

1대1 채팅에 대해서 채팅 기능 추가 완료 하였습니다. 
채팅 기능 관련한 DB 구조 및 로직을 시각화 하여 설명할 수 있도록 자료 작성 예정입니다.
또한 그룹 채팅 기능도 곧이어 추가하도록 하겠습니다.
