### PR TITLE
아이템 변경 로직 수정 등

### DIFF
--- a/src/main/java/com/example/naejango/domain/chat/api/ChannelController.java
+++ b/src/main/java/com/example/naejango/domain/chat/api/ChannelController.java
@@ -51,7 +51,7 @@ public class ChannelController {
                     new CommonResponseDto<>("일대일 채널이 개설 되었습니다.", result)
             );
         } else {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            return ResponseEntity.status(HttpStatus.OK).body(
                     new CommonResponseDto<>("이미 진행중인 채널이 있습니다.", result)
             );
         }

--- a/src/main/java/com/example/naejango/domain/chat/api/WebSocketController.java
+++ b/src/main/java/com/example/naejango/domain/chat/api/WebSocketController.java
@@ -47,7 +47,7 @@ public class WebSocketController {
                 .messageType(SUBSCRIBE_CHANNEL).content(SUBSCRIBE_CHANNEL.getDefaultMessage()).build();
     }
 
-    /** 특정 채팅 채널을 구독하는 WebSocket Endpoint */
+    /** 특정 라운지 채널을 구독하는 WebSocket Endpoint */
     @SubscribeMapping("/sub/lounge/{channelId}")
     public WebSocketMessageSendDto subscribeLoungeChannel(@DestinationVariable("channelId") Long channelId,
                                                              @Headers SimpMessageHeaderAccessor accessor) {

--- a/src/main/java/com/example/naejango/domain/item/api/ItemController.java
+++ b/src/main/java/com/example/naejango/domain/item/api/ItemController.java
@@ -1,7 +1,9 @@
 package com.example.naejango.domain.item.api;
 
 import com.example.naejango.domain.common.CommonResponseDto;
+import com.example.naejango.domain.item.application.CategoryService;
 import com.example.naejango.domain.item.application.ItemService;
+import com.example.naejango.domain.item.dto.CategoryDto;
 import com.example.naejango.domain.item.dto.MatchItemsRequestDto;
 import com.example.naejango.domain.item.dto.SearchItemInfoDto;
 import com.example.naejango.domain.item.dto.SearchingCommandDto;
@@ -30,6 +32,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ItemController {
     private final ItemService itemService;
+    private final CategoryService categoryService;
     private final AuthenticationHandler authenticationHandler;
     private final GeomUtil geomUtil;
 
@@ -57,6 +60,14 @@ public class ItemController {
 
         return ResponseEntity.ok().body(new CommonResponseDto<>("조회 성공", findItemResponseDto));
     }
+
+    /** 카테고리 조회 */
+    @GetMapping("/category")
+    public ResponseEntity<CommonResponseDto<List<CategoryDto>>> getCategory() {
+        List<CategoryDto> result = categoryService.findAllCategory();
+        return ResponseEntity.ok().body(new CommonResponseDto<>("조회 성공", result));
+    }
+
 
     /**
      * 아이템 검색

--- a/src/main/java/com/example/naejango/domain/item/application/CategoryService.java
+++ b/src/main/java/com/example/naejango/domain/item/application/CategoryService.java
@@ -1,0 +1,19 @@
+package com.example.naejango.domain.item.application;
+
+import com.example.naejango.domain.item.dto.CategoryDto;
+import com.example.naejango.domain.item.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryDto> findAllCategory() {
+         return categoryRepository.findAll().stream().map(CategoryDto::new).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/naejango/domain/item/application/ItemService.java
+++ b/src/main/java/com/example/naejango/domain/item/application/ItemService.java
@@ -91,7 +91,7 @@ public class ItemService {
     /** 아이템 정보 수정 */
     @Transactional
     public ModifyItemResponseDto modifyItem(Long userId, Long itemId, ModifyItemCommandDto modifyItemCommandDto) {
-        Category category = findCategoryByName(modifyItemCommandDto.getCategory());
+        Category category = findCategoryById(modifyItemCommandDto.getCategory());
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
 

--- a/src/main/java/com/example/naejango/domain/item/domain/Item.java
+++ b/src/main/java/com/example/naejango/domain/item/domain/Item.java
@@ -59,11 +59,10 @@ public class Item extends TimeAuditingEntity {
     @JoinColumn(name = "storage_id")
     private Storage storage;
 
-    public void modifyItem(String name, String description, String imgUrl, ItemType type, Category category) {
+    public void modifyItem(String name, String description, String imgUrl, Category category) {
         this.name = name;
         this.description = description;
         this.imgUrl = imgUrl;
-        this.itemType = type;
         this.category = category;
     }
 

--- a/src/main/java/com/example/naejango/domain/item/dto/CategoryDto.java
+++ b/src/main/java/com/example/naejango/domain/item/dto/CategoryDto.java
@@ -1,0 +1,19 @@
+package com.example.naejango.domain.item.dto;
+
+import com.example.naejango.domain.item.domain.Category;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CategoryDto {
+    private Integer categoryId;
+    private String categoryName;
+
+    public CategoryDto(Category category) {
+        this.categoryId = category.getId();
+        this.categoryName = category.getName();
+    }
+}

--- a/src/main/java/com/example/naejango/domain/item/dto/request/ModifyItemCommandDto.java
+++ b/src/main/java/com/example/naejango/domain/item/dto/request/ModifyItemCommandDto.java
@@ -2,7 +2,6 @@ package com.example.naejango.domain.item.dto.request;
 
 import com.example.naejango.domain.item.domain.Category;
 import com.example.naejango.domain.item.domain.Item;
-import com.example.naejango.domain.item.domain.ItemType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,20 +19,17 @@ public class ModifyItemCommandDto {
 
     private String imgUrl;
 
-    private ItemType itemType;
-
-    private String category;
+    private Integer category;
 
     public ModifyItemCommandDto(ModifyItemRequestDto modifyItemRequestDto) {
         this.name = modifyItemRequestDto.getName();
         this.description = modifyItemRequestDto.getDescription();
         this.imgUrl = modifyItemRequestDto.getImgUrl();
-        this.itemType = modifyItemRequestDto.getItemType();
         this.category = modifyItemRequestDto.getCategory();
     }
 
     public void toEntity(Item item, Category category) {
-        item.modifyItem(name, description, imgUrl, itemType, category);
+        item.modifyItem(name, description, imgUrl, category);
     }
 
 }

--- a/src/main/java/com/example/naejango/domain/item/dto/request/ModifyItemRequestDto.java
+++ b/src/main/java/com/example/naejango/domain/item/dto/request/ModifyItemRequestDto.java
@@ -1,7 +1,5 @@
 package com.example.naejango.domain.item.dto.request;
 
-import com.example.naejango.domain.item.domain.ItemType;
-import com.example.naejango.global.common.validation.EnumConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,9 +26,6 @@ public class ModifyItemRequestDto {
     @Size(max = 100)
     private String imgUrl;
 
-    @EnumConstraint(enumClass = ItemType.class, message = "올바른 Type을 입력하세요. (INDIVIDUAL_BUY/INDIVIDUAL_SELL/GROUP_BUY)")
-    private ItemType itemType;
-
-    private String category;
+    private Integer category;
 
 }

--- a/src/main/java/com/example/naejango/domain/item/repository/MatchItemDto.java
+++ b/src/main/java/com/example/naejango/domain/item/repository/MatchItemDto.java
@@ -16,8 +16,8 @@ import java.util.Arrays;
 public class MatchItemDto {
     private Item item;
     private Category category;
-    private int distance;
     private User user;
+    private Integer distance;
 
     public MatchResponseDto toResponseDto() {
         return MatchResponseDto.builder()

--- a/src/test/java/com/example/naejango/domain/chat/api/ChannelControllerTest.java
+++ b/src/test/java/com/example/naejango/domain/chat/api/ChannelControllerTest.java
@@ -87,7 +87,7 @@ class ChannelControllerTest extends RestDocsSupportTest {
             verify(authenticationHandlerMock, times(1)).getUserId(any());
             verify(channelServiceMock, times(1)).createPrivateChannel(anyLong(), anyLong());
 
-            resultActions.andExpect(status().isConflict());
+            resultActions.andExpect(status().isOk());
             resultActions.andExpect(content().json(objectMapper.writeValueAsString(
                     new CommonResponseDto<>("이미 진행중인 채널이 있습니다.", new ChannelAndChatDto(channel.getId(), chat.getId()))
             )));

--- a/src/test/java/com/example/naejango/domain/item/api/ItemControllerTest.java
+++ b/src/test/java/com/example/naejango/domain/item/api/ItemControllerTest.java
@@ -4,8 +4,11 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.example.naejango.domain.chat.repository.ChannelRepository;
 import com.example.naejango.domain.config.RestDocsSupportTest;
+import com.example.naejango.domain.item.application.CategoryService;
 import com.example.naejango.domain.item.application.ItemService;
+import com.example.naejango.domain.item.domain.Category;
 import com.example.naejango.domain.item.domain.ItemType;
+import com.example.naejango.domain.item.dto.CategoryDto;
 import com.example.naejango.domain.item.dto.SearchItemInfoDto;
 import com.example.naejango.domain.item.dto.request.CreateItemCommandDto;
 import com.example.naejango.domain.item.dto.request.CreateItemRequestDto;
@@ -34,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
@@ -47,6 +51,8 @@ class ItemControllerTest extends RestDocsSupportTest {
 
     @MockBean
     ItemService itemService;
+    @MockBean
+    CategoryService categoryService;
     @MockBean
     AuthenticationHandler authenticationHandler;
     @MockBean
@@ -217,8 +223,51 @@ class ItemControllerTest extends RestDocsSupportTest {
     }
 
     @Nested
-    @Tag("api")
+    @Order(3)
+    @DisplayName("모든 카테고리 조회")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class getCategory {
+        Category cat1 = new Category(1, "의류");
+        Category cat2 = new Category(2, "생필품");
+        Category cat3 = new Category(3, "디지털기기");
+        List<Category> result = List.of(cat1, cat2, cat3);
+        List<CategoryDto> resultDto = result.stream().map(CategoryDto::new).collect(Collectors.toList());
+
+        @Test
+        @Tag("api")
+        @DisplayName("성공")
+        void test1() throws Exception {
+            // given
+            BDDMockito.given(categoryService.findAllCategory()).willReturn(resultDto);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders
+                    .get("/api/item/category")
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+            );
+
+            // then
+
+            // restDoc
+            resultActions.andDo(restDocs.document(resource(ResourceSnippetParameters.builder()
+                    .tag("카테고리")
+                    .summary("카테고리 조회")
+                    .description("저장되어 있는 카테고리를 전부 조회합니다.")
+                    .responseFields(
+                            fieldWithPath("message").description("결과 메세지"),
+                            fieldWithPath("result[].categoryId").description("카테고리 아이디"),
+                            fieldWithPath("result[].categoryName").description("카테고리 이름"))
+                    .requestSchema(
+                            Schema.schema("카테고리 조회 Response"))
+                    .build()))
+            );
+        }
+    }
+
+    @Nested
+    @Order(4)
     @DisplayName("아이템 검색")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class SearchStorageByConditions {
         Point center = geomUtil.createPoint(127.02, 37.49);
         List<SearchItemInfoDto> searchItemInfoDtoList =
@@ -228,6 +277,7 @@ class ItemControllerTest extends RestDocsSupportTest {
                 ));
 
         @Test
+        @Tag("api")
         @DisplayName("모든 조건으로 아이템과 창고 검색")
         void 모든_조건으로_아이템과_창고_검색() throws Exception {
             // given
@@ -300,7 +350,8 @@ class ItemControllerTest extends RestDocsSupportTest {
     }
 
     @Nested
-    @Tag("api")
+    @Order(5)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @DisplayName("아이템 매치")
     class MatchItems {
         MatchResponseDto dto1 = MatchResponseDto.builder()
@@ -326,6 +377,7 @@ class ItemControllerTest extends RestDocsSupportTest {
                 .build();
 
         @Test
+        @Tag("api")
         @DisplayName("매치 성공")
         void test1() throws Exception {
             // given
@@ -380,7 +432,7 @@ class ItemControllerTest extends RestDocsSupportTest {
     }
 
     @Nested
-    @Order(3)
+    @Order(6)
     @DisplayName("Controller 아이템 정보 수정")
     @WithMockUser()
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -463,7 +515,7 @@ class ItemControllerTest extends RestDocsSupportTest {
     }
 
     @Nested
-    @Order(4)
+    @Order(7)
     @DisplayName("Controller 아이템 삭제")
     @WithMockUser()
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/src/test/java/com/example/naejango/domain/item/api/ItemControllerTest.java
+++ b/src/test/java/com/example/naejango/domain/item/api/ItemControllerTest.java
@@ -444,8 +444,7 @@ class ItemControllerTest extends RestDocsSupportTest {
                         .name("아이템 이름")
                         .description("아이템 설명")
                         .imgUrl("이미지 URL")
-                        .itemType(ItemType.INDIVIDUAL_SELL)
-                        .category("카테고리")
+                        .category(1)
                         .build();
 
         ModifyItemResponseDto modifyItemResponseDto =
@@ -465,7 +464,6 @@ class ItemControllerTest extends RestDocsSupportTest {
         void 아이템_정보_수정_성공() throws Exception {
             // given
             String content = objectMapper.writeValueAsString(modifyItemRequestDto);
-
             BDDMockito.given(authenticationHandler.getUserId(any()))
                     .willReturn(userId);
             BDDMockito.given(itemService.modifyItem(any(), any(), any(ModifyItemCommandDto.class)))
@@ -495,7 +493,6 @@ class ItemControllerTest extends RestDocsSupportTest {
                                             fieldWithPath("name").description("아이템 이름"),
                                             fieldWithPath("description").description("아이템 설명"),
                                             fieldWithPath("imgUrl").description("아이템 이미지 Url"),
-                                            fieldWithPath("itemType").description("아이템 타입 (INDIVIDUAL_BUY, INDIVIDUAL_SELL, GROUP_BUY)"),
                                             fieldWithPath("category").description("카테고리")
                                     )
                                     .responseFields(

--- a/src/test/java/com/example/naejango/domain/item/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/example/naejango/domain/item/repository/CategoryRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.example.naejango.domain.item.repository;
+
+import com.example.naejango.domain.item.domain.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CategoryRepositoryTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Nested
+    @DisplayName("카테고리 전부 조회")
+    class getCategoryTest {
+        @Test
+        @DisplayName("성공")
+        void test1(){
+            // given
+
+            // when
+            List<Category> all = categoryRepository.findAll();
+
+            // then
+            Assertions.assertFalse(all.isEmpty());
+        }
+    }
+
+}

--- a/src/test/java/com/example/naejango/domain/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/example/naejango/domain/item/repository/ItemRepositoryTest.java
@@ -211,11 +211,21 @@ class ItemRepositoryTest {
 
         @BeforeEach
         void setup() {
-            Storage testStorage4 = Storage.builder().name("테스트 창고 4").location(geomUtil.createPoint(127.021, 37.491)).address("").build();
-            Storage testStorage5 = Storage.builder().name("테스트 창고 5").location(geomUtil.createPoint(127.022, 37.492)).address("").build();
-            Storage testStorage6 = Storage.builder().name("테스트 창고 6").location(geomUtil.createPoint(127.023, 37.493)).address("").build();
-            Storage testStorage7 = Storage.builder().name("테스트 창고 7").location(geomUtil.createPoint(127.024, 37.494)).address("").build();
-            Storage testStorage8 = Storage.builder().name("테스트 창고 8").location(geomUtil.createPoint(127.025, 37.495)).address("").build();
+            User user1 = User.builder().userKey("test_1").password("null").role(Role.GUEST).build();
+            User user2 = User.builder().userKey("test_2").password("null").role(Role.GUEST).build();
+            User user3 = User.builder().userKey("test_3").password("null").role(Role.GUEST).build();
+            User user4 = User.builder().userKey("test_4").password("null").role(Role.GUEST).build();
+
+            em.persist(user1);
+            em.persist(user2);
+            em.persist(user3);
+            em.persist(user4);
+
+            Storage testStorage4 = Storage.builder().name("테스트 창고 4").location(geomUtil.createPoint(127.021, 37.491)).address("").user(user1).build();
+            Storage testStorage5 = Storage.builder().name("테스트 창고 5").location(geomUtil.createPoint(127.022, 37.492)).address("").user(user2).build();
+            Storage testStorage6 = Storage.builder().name("테스트 창고 6").location(geomUtil.createPoint(127.023, 37.493)).address("").user(user3).build();
+            Storage testStorage7 = Storage.builder().name("테스트 창고 7").location(geomUtil.createPoint(127.024, 37.494)).address("").user(user4).build();
+            Storage testStorage8 = Storage.builder().name("테스트 창고 8").location(geomUtil.createPoint(127.025, 37.495)).address("").user(user1).build();
 
             storageRepository.save(testStorage4);
             storageRepository.save(testStorage5);


### PR DESCRIPTION
- 아이템 변경 로직 수정 : 타입 변경 불가능 하게 설정
- 아이템 매치 및 검색 쿼리 수정 : 반경 조건 추가
- 카테고리 조회 api 및 test 추가
- 일대일 채널 생성 응답 수정 : 200 응답으로 변경